### PR TITLE
Multiline Package Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+test:
+	nvim --headless --noplugin -u tests/minimal_init.lua \
+		-c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua'}"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: test
 test:
 	nvim --headless --noplugin -u tests/minimal_init.lua \
 		-c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua'}"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ require("neotest").setup({
 })
 ```
 
+## Development
+
+Run the test suite locally with:
+
+```sh
+make test
+```
+
 ## Roadmap
 
 To be implemented:

--- a/lua/neotest-scala/utils.lua
+++ b/lua/neotest-scala/utils.lua
@@ -14,15 +14,24 @@ function M.get_position_name(position)
 end
 
 ---Get a package name from the top of the file.
+---Supports chained package declarations spanning multiple lines (e.g. `package foo` then `package bar`).
 ---@return string|nil
 function M.get_package_name(file)
     local success, lines = pcall(lib.files.read_lines, file)
     if not success then
         return nil
     end
-    local line = lines[1]
-    if vim.startswith(line, "package") then
-        return vim.split(line, " ")[2] .. "."
+    local parts = {}
+    for _, line in ipairs(lines) do
+        local pkg = line:match("^package%s+([%w%.]+)")
+        if pkg then
+            table.insert(parts, pkg)
+        elseif #parts > 0 then
+            break
+        end
+    end
+    if #parts > 0 then
+        return table.concat(parts, ".") .. "."
     end
     return ""
 end

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,6 @@
+local plenary_path = vim.env.PLENARY_PATH or (vim.fn.stdpath("data") .. "/lazy/plenary.nvim")
+
+vim.opt.rtp:prepend(plenary_path)
+vim.opt.rtp:prepend(".")
+
+vim.cmd("runtime plugin/plenary.vim")

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -1,0 +1,80 @@
+-- Note: This test file was generated with AI assistance. The solution (utils.lua) was not.
+
+-- Mock neotest.lib before loading utils to avoid pulling in the full neotest dependency chain.
+package.loaded["neotest.lib"] = {
+    files = {
+        read_lines = function(path)
+            if vim.fn.filereadable(path) == 0 then
+                error("File not found: " .. path)
+            end
+            return vim.fn.readfile(path)
+        end,
+    },
+}
+
+local utils = require("neotest-scala.utils")
+
+--- Write lines to a temp file and return its path.
+local function write_temp_file(lines)
+    local path = vim.fn.tempname()
+    vim.fn.writefile(lines, path)
+    return path
+end
+
+describe("get_package_name", function()
+    it("returns package name with trailing dot for single package line", function()
+        local path = write_temp_file({ "package foo", "", "class Bar" })
+        assert.equals("foo.", utils.get_package_name(path))
+    end)
+
+    it("joins two chained package lines", function()
+        local path = write_temp_file({ "package foo", "package bar", "", "class Baz" })
+        assert.equals("foo.bar.", utils.get_package_name(path))
+    end)
+
+    it("joins three chained package lines", function()
+        local path = write_temp_file({ "package foo", "package bar", "package baz", "", "class Qux" })
+        assert.equals("foo.bar.baz.", utils.get_package_name(path))
+    end)
+
+    it("handles dotted package name on a single line", function()
+        local path = write_temp_file({ "package foo.bar", "", "class Baz" })
+        assert.equals("foo.bar.", utils.get_package_name(path))
+    end)
+
+    it("stops at first non-package line", function()
+        local path = write_temp_file({ "package foo", "import bar.Baz", "package ignored" })
+        assert.equals("foo.", utils.get_package_name(path))
+    end)
+
+    it("returns empty string when no package declaration", function()
+        local path = write_temp_file({ "class Foo {}", "" })
+        assert.equals("", utils.get_package_name(path))
+    end)
+
+    it("returns empty string for empty file", function()
+        local path = write_temp_file({})
+        assert.equals("", utils.get_package_name(path))
+    end)
+
+    it("returns nil when file does not exist", function()
+        assert.is_nil(utils.get_package_name("/nonexistent/path/file.scala"))
+    end)
+end)
+
+describe("get_position_name", function()
+    it("strips quotes from test position name", function()
+        local position = { type = "test", name = '"my test name"' }
+        assert.equals("my test name", utils.get_position_name(position))
+    end)
+
+    it("returns name unchanged for non-test positions", function()
+        local position = { type = "namespace", name = '"MySpec"' }
+        assert.equals('"MySpec"', utils.get_position_name(position))
+    end)
+
+    it("returns name unchanged when no quotes present", function()
+        local position = { type = "test", name = "my test name" }
+        assert.equals("my test name", utils.get_position_name(position))
+    end)
+end)


### PR DESCRIPTION
Current solution does not take multi line package names like

```
package com.example
package company1
```